### PR TITLE
Add workflows for cloudpod release + testing

### DIFF
--- a/.github/workflows/cloudpod_release.yml
+++ b/.github/workflows/cloudpod_release.yml
@@ -10,7 +10,6 @@ on:
       - 'README.md'
     branches:
       - main
-      - cloudpod_workflow
             
 permissions:
   contents: write

--- a/.github/workflows/cloudpod_release.yml
+++ b/.github/workflows/cloudpod_release.yml
@@ -10,6 +10,7 @@ on:
       - 'README.md'
     branches:
       - main
+      - cloudpod_workflow
             
 permissions:
   contents: write
@@ -34,13 +35,11 @@ jobs:
           pip install -r requirements-dev.txt
 
       - name: Start LocalStack
-        env:
-          LOCALSTACK_API_KEY: ${{ secrets.LOCALSTACK_API_KEY }}
         run: |
           pip install localstack awscli-local[ver1]
           docker pull localstack/localstack:${{ inputs.release-tag || 'latest'}}
           # Start LocalStack in the background
-          LS_LOG=trace localstack start -d
+          localstack start -d
           # Wait 30 seconds for the LocalStack container to become ready before timing out
           echo "Waiting for LocalStack startup..."
           localstack wait -t 30

--- a/.github/workflows/cloudpod_release.yml
+++ b/.github/workflows/cloudpod_release.yml
@@ -35,9 +35,11 @@ jobs:
           pip install -r requirements-dev.txt
 
       - name: Start LocalStack
+        env:
+          LOCALSTACK_API_KEY: ${{ secrets.LOCALSTACK_API_KEY }}
         run: |
           pip install localstack awscli-local[ver1]
-          docker pull localstack/localstack:${{ inputs.release-tag || 'latest'}}
+          docker pull localstack/localstack-pro:${{ inputs.release-tag || 'latest'}}
           # Start LocalStack in the background
           localstack start -d
           # Wait 30 seconds for the LocalStack container to become ready before timing out

--- a/.github/workflows/cloudpod_release.yml
+++ b/.github/workflows/cloudpod_release.yml
@@ -4,12 +4,12 @@ on:
       release-tag:
         type: string
         required: true
+        description: This will be the version of the release, but will also be used as 'tag' for the localstack docker image
   push:
     paths-ignore:
       - 'README.md'
     branches:
       - main
-      - cloudpod_workflow # TODO remove
             
 permissions:
   contents: write
@@ -17,7 +17,7 @@ permissions:
 name: Create Release
 jobs:
   release:
-    name: Create Pod
+    name: Create Release for Cloud Pod
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/cloudpod_release.yml
+++ b/.github/workflows/cloudpod_release.yml
@@ -1,0 +1,97 @@
+on:
+  workflow_dispatch:
+    inputs:
+      release-tag:
+        type: string
+        required: true
+  push:
+    paths-ignore:
+      - 'README.md'
+    branches:
+      - main
+      - cloudpod_workflow # TODO remove
+            
+permissions:
+  contents: write
+
+name: Create Release
+jobs:
+  build:
+    name: Create Pod
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up Python 3.9
+        id: setup-python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+
+      - name: Set up Project
+        run: |
+          pip install -r requirements-dev.txt
+
+      - name: Start LocalStack
+        env:
+          LOCALSTACK_API_KEY: ${{ secrets.LOCALSTACK_API_KEY }}
+        run: |
+          pip install localstack awscli-local[ver1]
+          docker pull localstack/localstack:${{ inputs.release-tag || 'latest'}}
+          # Start LocalStack in the background
+          LS_LOG=trace localstack start -d
+          # Wait 30 seconds for the LocalStack container to become ready before timing out
+          echo "Waiting for LocalStack startup..."
+          localstack wait -t 30
+          echo "Startup complete"
+
+      - name: Deploy infrastructure
+        run: |
+          bin/deploy.sh
+
+      - name: Run Tests
+        env:
+          AWS_DEFAULT_REGION: us-east-1
+          AWS_REGION: us-east-1
+          AWS_ACCESS_KEY_ID: test
+          AWS_SECRET_ACCESS_KEY: test
+        run: |
+          pytest tests
+      
+      - name: Save the Cloud Pod 
+        uses: HarshCasper/cloud-pod-save@v0.1.0
+        with:
+          name: 'release-pod.zip'
+          location: 'disk'
+
+  upload:
+    needs: build
+    name: Upload Release Asset
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download Pod Artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: cloudpod
+
+      - name: Display structure of downloaded files
+        run: ls -R
+
+      - name: Prepare Release Notes
+        run: |
+          echo "This release includes the Cloud Pod of the sample created with LocalStack Version \`${{ inputs.release-tag || 'latest'}}\`." > Release.txt
+          echo "You can download the \`release-pod.zip\` and inject it manually by running \`localstack pod load file://release-pod.zip\`, or use the Cloud Pods Launchpad." >> Release.txt
+          echo "### Cloud Pods Launchpad" >> Release.txt
+          echo "You can click the Launchpad to inject the the pod into your running LocalStack instance using the WebUI:" >> Release.txt
+          echo "[![LocalStack Pods Launchpad](https://localstack.cloud/gh/launch-pod-badge.svg)](https://app.localstack.cloud/launchpad?url=https://github.com/$GITHUB_REPOSITORY/releases/download/${{ inputs.release-tag || 'latest'}}/release-pod.zip)" >> Release.txt
+
+      - name: Create Release
+        id: create_release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: "${{ inputs.release-tag || 'latest'}}"
+          name: "Cloud Pod for LocalStack Version '${{ inputs.release-tag || 'latest'}}'"
+          body_path: ./Release.txt
+          files: |
+              ./release-pod.zip

--- a/.github/workflows/cloudpod_release.yml
+++ b/.github/workflows/cloudpod_release.yml
@@ -16,7 +16,7 @@ permissions:
 
 name: Create Release
 jobs:
-  build:
+  release:
     name: Create Pod
     runs-on: ubuntu-latest
     steps:
@@ -65,11 +65,6 @@ jobs:
           name: 'release-pod.zip'
           location: 'disk'
 
-  upload:
-    needs: build
-    name: Upload Release Asset
-    runs-on: ubuntu-latest
-    steps:
       - name: Prepare Release Notes
         run: |
           echo "This release includes the Cloud Pod of the sample created with LocalStack Version \`${{ inputs.release-tag || 'latest'}}\`." > Release.txt

--- a/.github/workflows/cloudpod_release.yml
+++ b/.github/workflows/cloudpod_release.yml
@@ -70,14 +70,6 @@ jobs:
     name: Upload Release Asset
     runs-on: ubuntu-latest
     steps:
-      - name: Download Pod Artifacts
-        uses: actions/download-artifact@v3
-        with:
-          name: cloudpod
-
-      - name: Display structure of downloaded files
-        run: ls -R
-
       - name: Prepare Release Notes
         run: |
           echo "This release includes the Cloud Pod of the sample created with LocalStack Version \`${{ inputs.release-tag || 'latest'}}\`." > Release.txt

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -42,8 +42,6 @@ jobs:
           pip install -r requirements-dev.txt
 
       - name: Start LocalStack
-        env:
-          LOCALSTACK_API_KEY: ${{ secrets.LOCALSTACK_API_KEY }}
         run: |
           pip install localstack awscli-local[ver1]
           docker pull localstack/localstack

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -42,9 +42,11 @@ jobs:
           pip install -r requirements-dev.txt
 
       - name: Start LocalStack
+        env:
+          LOCALSTACK_API_KEY: ${{ secrets.LOCALSTACK_API_KEY }}
         run: |
           pip install localstack awscli-local[ver1]
-          docker pull localstack/localstack
+          docker pull localstack/localstack-pro
           # Start LocalStack in the background
           LS_LOG=trace localstack start -d
           # Wait 30 seconds for the LocalStack container to become ready before timing out

--- a/.github/workflows/test_cloudpods.yml
+++ b/.github/workflows/test_cloudpods.yml
@@ -24,7 +24,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        output=$(gh api repos/$GITHUB_REPOSITORY/releases |  jq -r '.[] | select(.tag_name|startswith("v")|not) | .tag_name')
+        output=$(gh api repos/$GITHUB_REPOSITORY/releases | jq -r '[.[] | select(.tag_name|startswith("v")|not) | .tag_name]')
         output=$(echo $output | tr '\n' ' ')
         echo "matrix=$output" >> $GITHUB_OUTPUT
   

--- a/.github/workflows/test_cloudpods.yml
+++ b/.github/workflows/test_cloudpods.yml
@@ -61,9 +61,10 @@ jobs:
         env:
           DEBUG: 1 
           POD_LOAD_CLI_TIMEOUT: 300
+          LOCALSTACK_API_KEY: ${{ secrets.LOCALSTACK_API_KEY }}
         run: |
           pip install localstack awscli-local[ver1]
-          docker pull localstack/localstack
+          docker pull localstack/localstack-pro:${{ matrix.tag }}
           # Start LocalStack in the background
           localstack start -d
           # Wait 30 seconds for the LocalStack container to become ready before timing out

--- a/.github/workflows/test_cloudpods.yml
+++ b/.github/workflows/test_cloudpods.yml
@@ -5,11 +5,7 @@ on:
     # “At 00:00 on Saturday.”
     - cron: "0 0 * * 6"
   workflow_dispatch:
-  push: # TODO remove just for testing
-    paths-ignore:
-      - 'README.md'
-    branches:
-      - cloudpod_workflow
+
 permissions:
   contents: write
 

--- a/.github/workflows/test_cloudpods.yml
+++ b/.github/workflows/test_cloudpods.yml
@@ -24,7 +24,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        output=$(gh api repos/$GITHUB_REPOSITORY/releases |  jq -r '.[] | select(.tag_name|startswith("v")|not) | .tag_name'')
+        output=$(gh api repos/$GITHUB_REPOSITORY/releases |  jq -r '.[] | select(.tag_name|startswith("v")|not) | .tag_name')
         output=$(echo $output | tr '\n' ' ')
         echo "matrix=$output" >> $GITHUB_OUTPUT
   

--- a/.github/workflows/test_cloudpods.yml
+++ b/.github/workflows/test_cloudpods.yml
@@ -1,0 +1,123 @@
+name: Test Released Cloud Pods
+
+on:
+  schedule:
+    # “At 00:00 on Saturday.”
+    - cron: "0 0 * * 6"
+  workflow_dispatch:
+  push: # TODO remove just for testing
+    paths-ignore:
+      - 'README.md'
+    branches:
+      - cloudpod_workflow
+permissions:
+  contents: write
+
+jobs:
+  get-releases:
+    name: Retrieve Released Cloud Pods
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+    - id: set-matrix
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        output=$(gh api repos/$GITHUB_REPOSITORY/releases |  jq -r '.[] | select(.tag_name|startswith("v")|not) | .tag_name'')
+        output=$(echo $output | tr '\n' ' ')
+        echo "matrix=$output" >> $GITHUB_OUTPUT
+  
+  test-pod-release:
+    needs: get-releases
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix: 
+        tag: ${{ fromJson(needs.get-releases.outputs.matrix) }}
+    steps:
+      # checkout to run the tests later on
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Retrieve Pod
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # TODO the download url seems to follow the pattern $GITHUB_REPOSITORY/releases/download/{TAG}/{ASSET_NAME}
+          # alternatively we can query the asset-id, and browser_download_url, but it seems like an overhead
+          # asset_id=$(gh api repos/$GITHUB_REPOSITORY/releases/tags/latest | jq -r '.assets[]' | jq --arg DB $DB -c 'select(.name=="release-pod-\( $DB ).zip") | .id)
+          # download_url=$(gh api repos/$GITHUB_REPOSITORY/releases/assets/$asset_id | jq -r ".browser_download_url")
+          download_url="https://github.com/$GITHUB_REPOSITORY/releases/download/${{ matrix.tag }}/release-pod-${{ matrix.db }}.zip"
+          curl -L $download_url --output release-pod.zip
+          ls -la
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+
+      - name: Install Dependencies
+        run: |
+          pip install localstack awscli-local
+
+      - name: Start LocalStack
+        env:
+          LOCALSTACK_API_KEY: ${{ secrets.LOCALSTACK_API_KEY }}
+          LOCALSTACK_VOLUME_DIR: ${{ github.workspace }}/ls_test
+          MYSQL_FEATURE_FLAG: ${{ matrix.db }}
+          DEBUG: 1 
+          POD_LOAD_CLI_TIMEOUT: 300
+        run: |
+          mkdir ls_test
+          ls -la ls_test
+          docker pull localstack/localstack-pro:${{ matrix.tag }}
+          # Start LocalStack in the background
+          if [ "mysql" ==  ${MYSQL_FEATURE_FLAG} ]; then
+            RDS_MYSQL_DOCKER=1 localstack start -d
+          else
+            localstack start -d
+          fi
+          # Wait 30 seconds for the LocalStack container to become ready before timing out
+          echo "Waiting for LocalStack startup..."
+          localstack wait -t 30
+          echo "Startup complete"
+
+      - name: Inject Pod
+        run: |
+          localstack pod load file://release-pod.zip
+
+      - name: Run Tests
+        env:
+          AWS_DEFAULT_REGION: us-east-1
+          AWS_REGION: us-east-1
+          AWS_ACCESS_KEY_ID: test
+          AWS_SECRET_ACCESS_KEY: test
+        run: |
+          pytest tests
+
+      - name: Show Logs
+        if: failure()
+        run: |
+          localstack logs
+
+ #     - name: Send a Slack notification
+ #       if: failure() || github.event_name != 'pull_request'
+ #       uses: ravsamhq/notify-slack-action@v2
+ #       with:
+ #         status: ${{ job.status }}
+ #         token: ${{ secrets.GITHUB_TOKEN }}
+ #         notification_title: "{workflow} has {status_message}"
+ #         message_format: "{emoji} *{workflow}* {status_message} in <{repo_url}|{repo}>"
+ #         footer: "Linked Repo <{repo_url}|{repo}> | <{run_url}|View Workflow run>"
+ #         notify_when: "failure"
+ #       env:
+ #         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
+ #     - name: Prevent Workflows from getting Stale
+ #       if: always()
+ #       uses: gautamkrishnar/keepalive-workflow@v1
+ #       with:
+            # this message should prevent automatic triggering of workflows
+            # see https://docs.github.com/en/actions/managing-workflow-runs/skipping-workflow-runs
+ #           commit_message: "[skip ci] Automated commit by Keepalive Workflow to keep the repository active"

--- a/.github/workflows/test_cloudpods.yml
+++ b/.github/workflows/test_cloudpods.yml
@@ -48,7 +48,7 @@ jobs:
           # alternatively we can query the asset-id, and browser_download_url, but it seems like an overhead
           # asset_id=$(gh api repos/$GITHUB_REPOSITORY/releases/tags/latest | jq -r '.assets[]' | jq --arg DB $DB -c 'select(.name=="release-pod-\( $DB ).zip") | .id)
           # download_url=$(gh api repos/$GITHUB_REPOSITORY/releases/assets/$asset_id | jq -r ".browser_download_url")
-          download_url="https://github.com/$GITHUB_REPOSITORY/releases/download/${{ matrix.tag }}/release-pod-${{ matrix.db }}.zip"
+          download_url="https://github.com/$GITHUB_REPOSITORY/releases/download/${{ matrix.tag }}/release-pod.zip"
           curl -L $download_url --output release-pod.zip
           ls -la
 

--- a/.github/workflows/test_cloudpods.yml
+++ b/.github/workflows/test_cloudpods.yml
@@ -83,6 +83,7 @@ jobs:
           AWS_ACCESS_KEY_ID: test
           AWS_SECRET_ACCESS_KEY: test
         run: |
+          pip install -r requirements-dev.txt
           pytest tests
 
       - name: Show Logs

--- a/.github/workflows/test_cloudpods.yml
+++ b/.github/workflows/test_cloudpods.yml
@@ -91,23 +91,23 @@ jobs:
         run: |
           localstack logs
 
- #     - name: Send a Slack notification
- #       if: failure() || github.event_name != 'pull_request'
- #       uses: ravsamhq/notify-slack-action@v2
- #       with:
- #         status: ${{ job.status }}
- #         token: ${{ secrets.GITHUB_TOKEN }}
- #         notification_title: "{workflow} has {status_message}"
- #         message_format: "{emoji} *{workflow}* {status_message} in <{repo_url}|{repo}>"
- #         footer: "Linked Repo <{repo_url}|{repo}> | <{run_url}|View Workflow run>"
- #         notify_when: "failure"
- #       env:
- #         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      - name: Send a Slack notification
+        if: failure() || github.event_name != 'pull_request'
+        uses: ravsamhq/notify-slack-action@v2
+        with:
+          status: ${{ job.status }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          notification_title: "{workflow} has {status_message}"
+          message_format: "{emoji} *{workflow}* {status_message} in <{repo_url}|{repo}>"
+          footer: "Linked Repo <{repo_url}|{repo}> | <{run_url}|View Workflow run>"
+          notify_when: "failure"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
- #     - name: Prevent Workflows from getting Stale
- #       if: always()
- #       uses: gautamkrishnar/keepalive-workflow@v1
- #       with:
-            # this message should prevent automatic triggering of workflows
-            # see https://docs.github.com/en/actions/managing-workflow-runs/skipping-workflow-runs
- #           commit_message: "[skip ci] Automated commit by Keepalive Workflow to keep the repository active"
+      - name: Prevent Workflows from getting Stale
+        if: always()
+        uses: gautamkrishnar/keepalive-workflow@v1
+        with:
+          # this message should prevent automatic triggering of workflows
+          # see https://docs.github.com/en/actions/managing-workflow-runs/skipping-workflow-runs
+          commit_message: "[skip ci] Automated commit by Keepalive Workflow to keep the repository active"

--- a/.github/workflows/test_cloudpods.yml
+++ b/.github/workflows/test_cloudpods.yml
@@ -57,27 +57,15 @@ jobs:
         with:
           python-version: '3.9'
 
-      - name: Install Dependencies
-        run: |
-          pip install localstack awscli-local
-
       - name: Start LocalStack
         env:
-          LOCALSTACK_API_KEY: ${{ secrets.LOCALSTACK_API_KEY }}
-          LOCALSTACK_VOLUME_DIR: ${{ github.workspace }}/ls_test
-          MYSQL_FEATURE_FLAG: ${{ matrix.db }}
           DEBUG: 1 
           POD_LOAD_CLI_TIMEOUT: 300
         run: |
-          mkdir ls_test
-          ls -la ls_test
-          docker pull localstack/localstack-pro:${{ matrix.tag }}
+          pip install localstack awscli-local[ver1]
+          docker pull localstack/localstack
           # Start LocalStack in the background
-          if [ "mysql" ==  ${MYSQL_FEATURE_FLAG} ]; then
-            RDS_MYSQL_DOCKER=1 localstack start -d
-          else
-            localstack start -d
-          fi
+          localstack start -d
           # Wait 30 seconds for the LocalStack container to become ready before timing out
           echo "Waiting for LocalStack startup..."
           localstack wait -t 30

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Serverless image resizer
 
-[![LocalStack Pods Launchpad](https://localstack.cloud/gh/launch-pod-badge.svg)](https://app.localstack.cloud/launchpad?url=https://github.com/localstack/serverless-image-resizer/releases/download/v1.0.0/serverless-image-resizer-cloudpod-v1.0.0.zip)
+[![LocalStack Pods Launchpad](https://localstack.cloud/gh/launch-pod-badge.svg)](https://app.localstack.cloud/launchpad?url=https://github.com/localstack/sample-serverless-image-resizer-s3-lambda/releases/download/latest/release-pod.zip)
 
 | Key          | Value                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
 |--------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -243,3 +243,23 @@ deploys the infrastructure to it, and then runs the integration tests.
 
 We appreciate your interest in contributing to our project and are always looking for new ways to improve the developer experience. We welcome feedback, bug reports, and even feature ideas from the community.
 Please refer to the [contributing file](CONTRIBUTING.md) for more details on how to get started. 
+
+## Cloud Pods
+
+[Cloud Pods](https://docs.localstack.cloud/user-guide/tools/cloud-pods/) are a mechanism that allows you to take a snapshot of the state in your current LocalStack instance, persist it to a storage backend, and easily share it with your team members.
+
+You can convert your current AWS infrastructure state to a Cloud Pod using the `localstack` CLI. 
+Check out our [Getting Started guide](https://docs.localstack.cloud/user-guide/tools/cloud-pods/getting-started/) and [LocalStack Cloud Pods CLI reference](https://docs.localstack.cloud/user-guide/tools/cloud-pods/pods-cli/) to learn more about Cloud Pods and how to use them.
+
+To inject a Cloud Pod you can use [Cloud Pods Launchpad](https://docs.localstack.cloud/user-guide/tools/cloud-pods/launchpad/) wich quickly injects Cloud Pods into your running LocalStack container. 
+
+Click here [![LocalStack Pods Launchpad](https://localstack.cloud/gh/launch-pod-badge.svg)](https://app.localstack.cloud/launchpad?url=https://github.com/localstack/sample-serverless-image-resizer-s3-lambda/releases/download/latest/release-pod.zip) to launch the Cloud Pods Launchpad and inject the Cloud Pod for this application by clicking the `Inject` button.
+
+
+Alternatively, you can inject the pod by using the `localstack` CLI. 
+First, you need to download the pod you want to inject from the [releases](https://github.com/localstack/sample-serverless-image-resizer-s3-lambda/releases).
+Then run:
+
+```sh
+localstack pod load file://$(pwd)/release-pod.zip
+```


### PR DESCRIPTION
This PR adds workflows to automatically create Cloud Pod releases, and to test the released Cloud Pods on a weekly basis.

### Releasing Cloud Pods
* `cloudpod_release.yml` can be run manually
  * set the `release-tag` for the release-version
  * be aware, that the `release-tag` is the same tag as the LocalStack version tag, that is used to create pod.
* it will re-create a release for `latest` for any pushes on main (e.g. we assume that the code changed).
* The release notes contain a Cloud Pod Launchpad as well.
* In theory, we can create a release for any LocalStack version by running the workflow, and setting the `release-tag` (which will be used for both: the LocalStack version and the version of the release)

### Testing Cloud Pods
* `test_cloudpods.yml` is scheduled to run weekly (for now only on Ubuntu)
* it contains a slack notifications hook, which will notify our dedicated slack channel if anything fails
  * NOTE: I decided not include the diagnose file, as I think it will be too big.
  * If the tests fail, we have the chance identify any regression with cloud pods
  * new version of the cloud pod must be created manually then
* the workflows checks every released version, and injects the pods (for each flavor), and runs the smoke tests
* also added the [gautamkrishnar/keepalive-workflow](https://github.com/marketplace/actions/keepalive-workflow) which will add empty commits to make sure the workflows stay active.


### README
* updated the README to contain information about Cloud Pods and the Launchpad